### PR TITLE
Support for tokens

### DIFF
--- a/wp-google-analytics.php
+++ b/wp-google-analytics.php
@@ -402,17 +402,10 @@ class wpGoogleAnalytics {
 			$all_tokens = wp_list_pluck( $this->tokens, 'token' );
 			if ( in_array( $custom_var['value'], $all_tokens ) ) {
 				$token = array_pop( wp_filter_object_list( $this->tokens, array( 'token' => $custom_var['value'] ) ) );
-				if ( is_callable( $token['callback'] ) )
-					$replace = call_user_func( $token['callback'] );
-				else
-					$replace = '';
-
-				if ( ! empty( $token['callback_returns'] ) && 'bool' == $token['callback_returns'] )
-					$replace = ( $replace ) ? 'true' : 'false';
 
 				// Allow tokens to return empty values for specific contexts
+				$ignore = false;
 				if ( ! empty( $token['ignore_when'] ) ) {
-					$ignore = false;
 					foreach( (array)$token['ignore_when'] as $conditional ) {
 						if ( is_callable( $conditional ) ) {
 							$ignore = call_user_func( $conditional );
@@ -420,10 +413,18 @@ class wpGoogleAnalytics {
 								break;
 						}
 					}
-					if ( $ignore )
-						$replace = '';
 				}
 
+				// If we aren't set to ignore this context, possibly execute the callback
+				if ( ! $ignore && ! empty( $token['callback'] ) && is_callable( $token['callback'] ) )
+					$replace = call_user_func( $token['callback'] );
+				else
+					$replace = '';
+
+				if ( ! empty( $token['callback_returns'] ) && 'bool' == $token['callback_returns'] )
+					$replace = ( $replace ) ? 'true' : 'false';
+
+				// Replace our token with the value
 				$custom_var['value'] = str_replace( $custom_var['value'], $replace, $custom_var['value'] );
 			}
 

--- a/wp-google-analytics.php
+++ b/wp-google-analytics.php
@@ -79,8 +79,12 @@ class wpGoogleAnalytics {
 						'retval'           => __( "Post author's display name", 'wp-google-analytics' ),
 						'ignore_when'      => array(
 								'is_home',
-								'is_archive',
+								'is_front_page',
+								'is_post_type_archive',
 								'is_page',
+								'is_date',
+								'is_category',
+								'is_tag',
 							),
 					),
 				array(
@@ -91,8 +95,11 @@ class wpGoogleAnalytics {
 						'retval'           => __( "Category names in a commma-separated list", 'wp-google-analytics' ),
 						'ignore_when'      => array(
 								'is_home',
+								'is_front_page',
 								'is_page',
-								'is_archive',
+								'is_post_type_archive',
+								'is_author',
+								'is_tag',
 							),
 					),
 				array(
@@ -103,7 +110,12 @@ class wpGoogleAnalytics {
 						'retval'           => __( "Format specified by 'Date Format' in Settings -> General", 'wp-google-analytics' ),
 						'ignore_when'      => array(
 								'is_home',
+								'is_front_page',
+								'is_post_type_archive',
 								'is_page',
+								'is_author',
+								'is_category',
+								'is_tag',
 							),
 					),
 				array(
@@ -114,8 +126,12 @@ class wpGoogleAnalytics {
 						'retval'           => __( "Tag names in a commma-separated list", 'wp-google-analytics' ),
 						'ignore_when'      => array(
 								'is_home',
+								'is_front_page',
 								'is_page',
-								'is_archive',
+								'is_post_type_archive',
+								'is_date',
+								'is_category',
+								'is_author',
 							),
 					),
 				array(

--- a/wp-google-analytics.php
+++ b/wp-google-analytics.php
@@ -84,6 +84,18 @@ class wpGoogleAnalytics {
 							),
 					),
 				array(
+						'token'            => '%the_category%',
+						'callback'         => array( $this, 'token_the_category' ),
+						'callback_returns' => 'string',
+						'description'      => __( 'Categories assigned to a post', 'wp-google-analytics' ),
+						'retval'           => __( "Category names in a commma-separated list", 'wp-google-analytics' ),
+						'ignore_when'      => array(
+								'is_home',
+								'is_page',
+								'is_archive',
+							),
+					),
+				array(
 						'token'            => '%the_date%',
 						'callback'         => 'get_the_date',
 						'callback_returns' => 'string',
@@ -92,6 +104,18 @@ class wpGoogleAnalytics {
 						'ignore_when'      => array(
 								'is_home',
 								'is_page',
+							),
+					),
+				array(
+						'token'            => '%the_tags%',
+						'callback'         => array( $this, 'token_the_tags' ),
+						'callback_returns' => 'string',
+						'description'      => __( 'Tags assigned to a post', 'wp-google-analytics' ),
+						'retval'           => __( "Tag names in a commma-separated list", 'wp-google-analytics' ),
+						'ignore_when'      => array(
+								'is_home',
+								'is_page',
+								'is_archive',
 							),
 					),
 				array(
@@ -479,6 +503,20 @@ class wpGoogleAnalytics {
 		$wga = $this->_get_options();
 		if ( 'true' == $wga['log_outgoing'] && (!defined('XMLRPC_REQUEST') || !XMLRPC_REQUEST) && ( ! is_admin() || $wga['ignore_admin_area'] == 'false') )
 			wp_enqueue_script( 'wp-google-analytics', plugin_dir_url( __FILE__ ) . 'wp-google-analytics.js', array( 'jquery' ), '0.0.3' );
+	}
+
+	/**
+	 * Callback for %the_category% token
+	 */
+	public function token_the_category() {
+		return implode( ', ', wp_list_pluck( (array)get_the_category(), 'name' ) );
+	}
+
+	/**
+	 * Callback for %the_tags% token
+	 */
+	public function token_the_tags() {
+		return implode( ', ', wp_list_pluck( (array)get_the_tags(), 'name' ) );
 	}
 
 }


### PR DESCRIPTION
Tokens allow custom vars to be dynamic based on the context of the page or post being viewed. The token, callback, description, and retval items are rewrited. 'ignore_when' allows you to default to a null value for certain contexts.

A filter allows more tokens to be registered, although I think the list needs to be fleshed out a bit.
