### PR TITLE
Added support for custom events via shortcode filters.

### DIFF
--- a/languages/wp-google-analytics.pot
+++ b/languages/wp-google-analytics.pot
@@ -118,6 +118,18 @@ msgstr ""
 msgid "Log outgoing links as events"
 msgstr ""
 
+#: wp-google-analytics.php:223
+msgid "Use shortcodes to generate custom events for outgoing links"
+msgstr ""
+
+#: wp-google-analytics.php:232
+msgid "Specify the shortcode as <br /><strong>[wga_event category="category name" action="action name"]</strong> some-html-with-external-links <strong>[/wga_event]</strong>."
+msgstr ""
+
+#: wp-google-analytics.php:233
+msgid "You can also specify the label, value or noninteraction options for the event as <br /><strong>[wga_event category="cat name" action="act name" label="label string"]</strong> some-html <strong>[/wga_event]</strong>,<br /><strong>[wga_event category="cat name" action="act name" value="some value"]</strong> some-html <strong>[/wga_event]</strong> or<br /><strong>[wga_event category="cat name" action="act name" noninteraction="true"]</strong> some-html <strong>[/wga_event]</strong>."
+msgstr ""
+
 #: wp-google-analytics.php:227
 msgid "Default"
 msgstr ""
@@ -160,6 +172,14 @@ msgstr ""
 
 #: wp-google-analytics.php:326
 msgid "Update Options"
+msgstr ""
+
+#: wp-google-analytics.php:618
+msgid "Default category"
+msgstr ""
+
+#: wp-google-analytics.php:620
+msgid "Default action"
 msgstr ""
 
 #. Plugin Name of the plugin/theme

--- a/wp-google-analytics.js
+++ b/wp-google-analytics.js
@@ -1,29 +1,51 @@
 (function($){ // Open closure and map jQuery to $.
 
-	// Adds :external for grabbing external links
-	$.expr[':'].external = function(obj) {
+	var custom = function(obj) {
+		// It's a custom event if the link is inside a span.wgaevent container
+		return ( $(obj).closest('span.wgaevent').length >= 1 );
+	}
+
+	var external = function(obj) {
 		return !obj.href.match(/^mailto\:/) && !obj.href.match(/^javascript\:/) && (obj.hostname != location.hostname);
+	}
+
+	// Adds :external for grabbing external links (that don't belong tu custom events!)
+	$.expr[':'].external = function(obj) {
+		return ( wga_settings.external == 'true' ) && !custom(obj) && external(obj);
 	};
+
+	// Adds :custom for custom events (they don't have to be external links!)
+	$.expr[':'].custom = function(obj) {
+		return ( wga_settings.custom == 'true' ) && custom(obj);
+	};
+
+	var send_event = function(e, href, params) {
+		try {
+			_gaq.push( [ '_trackEvent' ].concat( params ) );
+			/**
+			 * If this link is not opened in a new tab or window, we need to add
+			 * a small delay so the event can fully fire.  See:
+			 * http://support.google.com/analytics/bin/answer.py?hl=en&answer=1136920
+			 *
+			 * We're actually checking for modifier keys or middle-click
+			 */
+			if ( ! ( e.metaKey || e.ctrlKey || 1 == e.button ) ) {
+				e.preventDefault();
+				setTimeout('document.location = "' + href + '"', 100)
+			}
+		} catch(err) {}
+	}
 
 	// Document ready.
 	$( function() {
 		// Add 'external' class and _blank target to all external links
 		$('a:external').on( 'click.wp-google-analytics', function(e){
-			try {
-				_gaq.push( [ '_trackEvent', 'Outbound Links', e.currentTarget.host, $(this).attr('href') ] );
-				/**
-				 * If this link is not opened in a new tab or window, we need to add
-				 * a small delay so the event can fully fire.  See:
-				 * http://support.google.com/analytics/bin/answer.py?hl=en&answer=1136920
-				 *
-				 * We're actually checking for modifier keys or middle-click
-				 */
-				if ( ! ( e.metaKey || e.ctrlKey || 1 == e.button ) ) {
-					e.preventDefault();
-					setTimeout('document.location = "' + $(this).attr('href') + '"', 100)
-				}
-			} catch(err) {}
+			send_event( e, $(this).attr('href'), [ 'Outbound Links', e.currentTarget.host, $(this).attr('href') ] );
 		});
+
+		$('a:custom').on( 'click.wp-google-analytics', function(e){
+ 			send_event( e, $(this).attr('href'), $(this).closest('span.wgaevent').data().wgaevent );
+		});			
 	});
 
 })( jQuery ); // Close closure.


### PR DESCRIPTION
I've developed a small patch (against current trunk version) that allows you to use shortcodes (both in articles/pages and text widgets) to create custom Google Analytics events for links (both internal and external).

Using the shortcodes you can specify any of the Google Analytics events' details: category, action, label, value and noninteractio)n with the following syntax:

```
[wga_event category="My Category" action="My Action"] an html link [/wga_event]
```

If you don't specify the category and action values, default values are used (as Google Analytics consider them mandatory).

Signed-off-by: Iñaki Arenaza iarenaza@mondragon.edu
