### PR TITLE
Handling of target=_blank attribute

### DIFF
--- a/wp-google-analytics.js
+++ b/wp-google-analytics.js
@@ -10,15 +10,17 @@
 		// Add 'external' class and _blank target to all external links
 		$('a:external').on( 'click.wp-google-analytics', function(e){
 			try {
+				// If link has target attribute, store for use below
+				var target = $(this).attr("target");
 				_gaq.push( [ '_trackEvent', 'Outbound Links', e.currentTarget.host, $(this).attr('href') ] );
 				/**
 				 * If this link is not opened in a new tab or window, we need to add
 				 * a small delay so the event can fully fire.  See:
 				 * http://support.google.com/analytics/bin/answer.py?hl=en&answer=1136920
 				 *
-				 * We're actually checking for modifier keys or middle-click
+				 * We're actually checking for modifier keys, middle-click, or pre-existing target=_blank attribute
 				 */
-				if ( ! ( e.metaKey || e.ctrlKey || 1 == e.button ) ) {
+				if ( ! ( e.metaKey || e.ctrlKey || 1 == e.button || target=="_blank"  ) ) {
 					e.preventDefault();
 					setTimeout('document.location = "' + $(this).attr('href') + '"', 100)
 				}

--- a/wp-google-analytics.js
+++ b/wp-google-analytics.js
@@ -10,8 +10,6 @@
 		// Add 'external' class and _blank target to all external links
 		$('a:external').on( 'click.wp-google-analytics', function(e){
 			try {
-				// If link has target attribute, store for use below
-				var target = $(this).attr("target");
 				_gaq.push( [ '_trackEvent', 'Outbound Links', e.currentTarget.host, $(this).attr('href') ] );
 				/**
 				 * If this link is not opened in a new tab or window, we need to add
@@ -20,7 +18,7 @@
 				 *
 				 * We're actually checking for modifier keys, middle-click, or pre-existing target=_blank attribute
 				 */
-				if ( ! ( e.metaKey || e.ctrlKey || 1 == e.button || target=="_blank"  ) ) {
+				if ( ! ( e.metaKey || e.ctrlKey || 1 == e.button || '_blank' == $(this).attr('target')  ) ) {
 					e.preventDefault();
 					setTimeout('document.location = "' + $(this).attr('href') + '"', 100)
 				}


### PR DESCRIPTION
Hi!  On a WP VIP site I'm working on, I noticed that the wp-google-analytics plugin is causing the target=_blank attributes on "Read More" links to be ignored, opening the new link in the same tab.  The code below adds a check for this behavior so that the attribute is handled correctly.

Thanks for your work on this great plugin!
